### PR TITLE
Added basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx:alpine
+
+COPY ./ /usr/share/nginx/html/
+
+# Expose port 80 for the container
+EXPOSE 80
+
+# Start Nginx when the container runs
+CMD ["nginx", "-g", "daemon off;"]
+


### PR DESCRIPTION
This PR adds a minimal Dockerfile. This Dockerfile will build a basic compact image based on alpine that can be run the website. I have used it successfully to run gwplotter behind the reverse proxy "Traefik", though nginx should work as well.

Instructions on how to do that can vary per host, so I have not included those.